### PR TITLE
Transfert code, new process for multi-atlas

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 Sherbrooke Connectivity Imaging Lab
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
-# freesurfer-nf
+FreeSurfer pipeline
+===================
+
+Run the FreeSurfer recon-all pipeline.
+
+If you use this pipeline, please cite:
+
+```
+Kurtzer GM, Sochat V, Bauer MW (2017)
+Singularity: Scientific containers for mobility of compute.
+PLoS ONE 12(5): e0177459. https://doi.org/10.1371/journal.pone.0177459
+
+P. Di Tommaso, et al. Nextflow enables reproducible computational workflows.
+Nature Biotechnology 35, 316–319 (2017) doi:10.1038/nbt.3820
+```
+
+Requirements
+------------
+
+- [Nextflow](https://www.nextflow.io)
+- FreeSurfer
+
+Usage
+-----
+
+See *USAGE* or run `nextflow run main.nf --help`

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-FreeSurfer pipeline
+# FreeSurfer pipeline
 ===================
 
 Run the FreeSurfer recon-all pipeline.
@@ -6,19 +6,22 @@ Run the FreeSurfer recon-all pipeline.
 If you use this pipeline, please cite:
 
 ```
-Kurtzer GM, Sochat V, Bauer MW (2017)
-Singularity: Scientific containers for mobility of compute.
-PLoS ONE 12(5): e0177459. https://doi.org/10.1371/journal.pone.0177459
+Fischl, Bruce. "FreeSurfer." Neuroimage 62.2 (2012)
+https://dx.doi.org/10.1016%2Fj.neuroimage.2012.01.021
+
+Kurtzer GM, Sochat V, Bauer MW Singularity: Scientific containers for
+mobility of compute. PLoS ONE 12(5): e0177459 (2017)
+https://doi.org/10.1371/journal.pone.0177459
 
 P. Di Tommaso, et al. Nextflow enables reproducible computational workflows.
-Nature Biotechnology 35, 316–319 (2017) doi:10.1038/nbt.3820
+Nature Biotechnology 35, 316–319 (2017) https://doi.org/10.1038/nbt.3820
 ```
 
 Requirements
 ------------
 
 - [Nextflow](https://www.nextflow.io)
-- FreeSurfer
+- FreeSurfer (https://surfer.nmr.mgh.harvard.edu/)
 
 Usage
 -----

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Requirements
 ------------
 
 - [Nextflow](https://www.nextflow.io)
-- FreeSurfer (https://surfer.nmr.mgh.harvard.edu/)
+- [FreeSurfer](https://surfer.nmr.mgh.harvard.edu/)
+- [scilpy](https://github.com/scilus/scilpy)
 
 Usage
 -----

--- a/USAGE
+++ b/USAGE
@@ -26,7 +26,7 @@ DESCRIPTION
 OPTIONAL ARGUMENTS (current value)
 --atlas_utils_folder                    Folder needed for other atlas conversion ($atlas_utils_folder)
 --nb_threads                            Number of threads used by recon-all ($nb_threads)
---brainstem_structures                  Uses the Freesurfer option for brainstem structures (3 ROIs instead of 1)
+--brainstem_structures                  Uses the Freesurfer option for brainstem structures, 3 ROIs instead of 1 ($brainstem_structures)
 
 NOTES
 

--- a/USAGE
+++ b/USAGE
@@ -1,0 +1,44 @@
+FreeSurfer pipeline
+===================
+
+Run recon-all on all encountered subjects
+
+USAGE
+
+nextflow run main.nf [OPTIONAL_ARGUMENTS] --root
+
+DESCRIPTION
+
+    --root_fs_input = false=/path/to/[root]     Root folder containing multiple subjects
+                                                [root]
+                                                ├── S1
+                                                │   └── t1.nii.gz
+                                                └── S2
+                                                    └── t1.nii.gz
+
+    --root_fs_output = false=/path/to/[root]    Root folder containing multiple subjects
+                                                [root]
+                                                ├── S1
+                                                │   └── label, mri, [...], stats, surf, touch
+                                                └── S2
+                                                    └── label, mri, [...], stats, surf, touch
+
+OPTIONAL ARGUMENTS (current value)
+--atlas_utils_folder                    Folder needed for other atlas conversion ($atlas_utils_folder)
+--nb_threads                            Number of threads used by recon-all ($nb_threads)
+--brainstem_structures                  Uses the Freesurfer option for brainstem structures (3 ROIs instead of 1)
+
+NOTES
+
+To set the number of parallel processes to launch, please use:
+'nextflow run -qs {nb_processes}'.
+
+Need to have FreeSurfer v. 6.0
+
+The intermediate working directory is, by default, set to './work'.
+To change it, use the '-w WORK_DIR' argument.
+
+The default config file is freesurfer_pipeline/nextflow.config.
+Use '-C config_file.config' to specify a non-default configuration file.
+The '-C config_file.config' must be inserted after the nextflow call
+like 'nextflow -C config_file.config run ...'.

--- a/main.nf
+++ b/main.nf
@@ -61,8 +61,6 @@ else {
     in_folders = Channel.empty()
 }
 
-atlas_utils_folder = Channel.fromPath("$params.atlas_utils_folder")
-
 process Recon_All {
     cpus params.nb_threads
 
@@ -85,13 +83,12 @@ process Recon_All {
 
 in_folders
     .concat(folders_for_atlases)
-    .combine(atlas_utils_folder)
     .set{all_folders_for_atlases}
 process Generate_Atlases {
     cpus params.nb_threads
 
     input:
-    set sid, file(folder), file(utils) from all_folders_for_atlases
+    set sid, file(folder) from all_folders_for_atlases
 
     output:
     set sid, "$sid/FS_BN_GL_Atlas/"
@@ -104,7 +101,7 @@ process Generate_Atlases {
     else
         version=FS_BN_GL_utils_without_brainstem_structures
     fi
-    ln -s ${utils}/fsaverage \$(dirname ${folder})/
-    bash ${utils}/\${version}/generate_atlas_BN_FS_v2.sh \$(dirname ${folder}) ${sid} ${params.nb_threads} FS_BN_GL_Atlas/
+    ln -s $params.atlas_utils_folder/fsaverage \$(dirname ${folder})/
+    bash $params.atlas_utils_folder/\${version}/generate_atlas_BN_FS_v2.sh \$(dirname ${folder}) ${sid} ${params.nb_threads} FS_BN_GL_Atlas/
     """
 }

--- a/main.nf
+++ b/main.nf
@@ -4,6 +4,7 @@ params.root_fs_input = false
 params.root_fs_output = false
 params.help = false
 
+
 if(params.help) {
     usage = file("$baseDir/USAGE")
 
@@ -61,7 +62,7 @@ process Recon_All {
     script:
     """
     export SUBJECTS_DIR=.
-    if [ ${params.brainstem_structures} ]; then
+    if ${params.brainstem_structures}; then
         recon-all -i $anat -s $sid -all -parallel -openmp $params.nb_threads -brainstem-structures
     else
         recon-all -i $anat -s $sid -all -parallel -openmp $params.nb_threads
@@ -84,7 +85,7 @@ process Generate_Atlases {
     script:
     """
     echo ${folder}
-    if [ ${params.brainstem_structures} ]; then
+    if ${params.brainstem_structures}; then
         version=FS_BN_GL_utils_with_brainstem_structures
     else
         version=FS_BN_GL_utils_without_brainstem_structures

--- a/main.nf
+++ b/main.nf
@@ -50,6 +50,9 @@ in_folders = Channel.fromPath("$root_fs_output/*/", type: 'dir')
 else {
     in_folders = Channel.empty()
 }
+
+atlas_utils_folder = Channel.fromPath("$params.atlas_utils_folder")
+
 process Recon_All {
     cpus params.nb_threads
 
@@ -72,12 +75,13 @@ process Recon_All {
 
 in_folders
     .concat(folders_for_atlases)
+    .combine(atlas_utils_folder)
     .set{all_folders_for_atlases}
 process Generate_Atlases {
     cpus params.nb_threads
 
     input:
-    set sid, file(folder) from all_folders_for_atlases
+    set sid, file(folder), file(utils) from all_folders_for_atlases
 
     output:
     set sid, "$sid/FS_BN_GL_Atlas/"
@@ -90,7 +94,7 @@ process Generate_Atlases {
     else
         version=FS_BN_GL_utils_without_brainstem_structures
     fi
-    ln -s ${params.atlas_utils_folder}/fsaverage \$(dirname ${folder})/
-    bash ${params.atlas_utils_folder}\${version}/generate_atlas_BN_FS_v2.sh \$(dirname ${folder}) ${sid} ${params.nb_threads} FS_BN_GL_Atlas/
+    ln -s ${utils}/fsaverage \$(dirname ${folder})/
+    bash ${utils}/\${version}/generate_atlas_BN_FS_v2.sh \$(dirname ${folder}) ${sid} ${params.nb_threads} FS_BN_GL_Atlas/
     """
 }

--- a/main.nf
+++ b/main.nf
@@ -1,17 +1,12 @@
 #!/usr/bin/env nextflow
 
-params.root_fs_input = false
-params.root_fs_output = false
-params.help = false
-
-
 if(params.help) {
     usage = file("$baseDir/USAGE")
 
     cpu_count = Runtime.runtime.availableProcessors()
-    bindings = ["nb_threads":"$params.nb_threads"]
-    bindings = ["atlas_utils_folder":"$params.atlas_utils_folder"]
-    bindings = ["brainstem_structures":"$params.brainstem_structures"]
+    bindings = ["nb_threads":"$params.nb_threads",
+                "atlas_utils_folder":"$params.atlas_utils_folder",
+                "brainstem_structures":"$params.brainstem_structures"]
 
     engine = new groovy.text.SimpleTemplateEngine()
     template = engine.createTemplate(usage.text).make(bindings)
@@ -24,14 +19,29 @@ log.info "Run Freesurfer"
 log.info "========================="
 log.info ""
 
+log.info ""
+log.info "Start time: $workflow.start"
+log.info ""
+
 log.debug "[Command-line]"
 log.debug "$workflow.commandLine"
 log.debug ""
-log.debug "Thanks to Félix C. Morency from imeka.ca for the inspiration."
+
+log.info "[Git Info]"
+log.info "$workflow.repository - $workflow.revision [$workflow.commitId]"
+log.info ""
 
 log.info "[Inputs]"
 log.info "Root FS Input: $params.root_fs_input"
 log.info "Root FS Output: $params.root_fs_output"
+
+log.info "Options"
+log.info "======="
+log.info ""
+log.info "Number of Thread: $params.nb_threads"
+log.info "Atlas Utils Folder: $params.atlas_utils_folder"
+log.info "Brainstem Structures: $params.brainstem_structures"
+log.info ""
 
 if (params.root_fs_input) {
 root_fs_input = file(params.root_fs_input)

--- a/main.nf
+++ b/main.nf
@@ -1,0 +1,95 @@
+#!/usr/bin/env nextflow
+
+params.root_fs_input = false
+params.root_fs_output = false
+params.help = false
+
+if(params.help) {
+    usage = file("$baseDir/USAGE")
+
+    cpu_count = Runtime.runtime.availableProcessors()
+    bindings = ["nb_threads":"$params.nb_threads"]
+    bindings = ["atlas_utils_folder":"$params.atlas_utils_folder"]
+    bindings = ["brainstem_structures":"$params.brainstem_structures"]
+
+    engine = new groovy.text.SimpleTemplateEngine()
+    template = engine.createTemplate(usage.text).make(bindings)
+
+    print template.toString()
+    return
+}
+
+log.info "Run Freesurfer"
+log.info "========================="
+log.info ""
+
+log.debug "[Command-line]"
+log.debug "$workflow.commandLine"
+log.debug ""
+log.debug "Thanks to Félix C. Morency from imeka.ca for the inspiration."
+
+log.info "[Inputs]"
+log.info "Root FS Input: $params.root_fs_input"
+log.info "Root FS Output: $params.root_fs_output"
+
+if (params.root_fs_input) {
+root_fs_input = file(params.root_fs_input)
+in_files = Channel.fromPath("$root_fs_input/**/*t1.nii.gz")
+    .map{ch1 -> [ch1.parent.name, ch1]}
+}
+else {
+    in_files = Channel.empty()
+}
+
+if (params.root_fs_output) {
+root_fs_output = file(params.root_fs_output)
+in_folders = Channel.fromPath("$root_fs_output/*/", type: 'dir')
+    .map{ch1 -> [ch1.name, ch1]}
+}
+else {
+    in_folders = Channel.empty()
+}
+process Recon_All {
+    cpus params.nb_threads
+
+    input:
+    set sid, file(anat) from in_files
+
+    output:
+    set sid, "$sid/" into folders_for_atlases
+
+    script:
+    """
+    export SUBJECTS_DIR=.
+    if [ ${params.brainstem_structures} ]; then
+        recon-all -i $anat -s $sid -all -parallel -openmp $params.nb_threads -brainstem-structures
+    else
+        recon-all -i $anat -s $sid -all -parallel -openmp $params.nb_threads
+    fi
+    """
+}
+
+in_folders
+    .concat(folders_for_atlases)
+    .set{all_folders_for_atlases}
+process Generate_Atlases {
+    cpus params.nb_threads
+
+    input:
+    set sid, file(folder) from all_folders_for_atlases
+
+    output:
+    set sid, "$sid/FS_BN_GL_Atlas/"
+
+    script:
+    """
+    echo ${folder}
+    if [ ${params.brainstem_structures} ]; then
+        version=FS_BN_GL_utils_with_brainstem_structures
+    else
+        version=FS_BN_GL_utils_without_brainstem_structures
+    fi
+    ln -s ${params.atlas_utils_folder}/fsaverage \$(dirname ${folder})/
+    bash ${params.atlas_utils_folder}\${version}/generate_atlas_BN_FS_v2.sh \$(dirname ${folder}) ${sid} ${params.nb_threads} FS_BN_GL_Atlas/
+    """
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -7,11 +7,11 @@ process {
 }
 
 params {
-    root_fs_input = false
-    root_fs_output = false
-    help = false
+    root_fs_input=false
+    root_fs_output=false
+    help=false
 
-    nb_threads = 4
-    atlas_utils_folder = /FS_BN_GL_utils /
-    brainstem_structures = false
+    nb_threads=4
+    atlas_utils_folder="/FS_BN_GL_utils/"
+    brainstem_structures=false
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -15,3 +15,11 @@ params {
     atlas_utils_folder="/FS_BN_GL_utils/"
     brainstem_structures=false
 }
+
+singularity.autoMounts = true
+
+profiles {
+    macos {
+            process.scratch="/tmp"
+    }
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -8,6 +8,6 @@ process {
 
 params {
     nb_threads=4
-    atlas_utils_folder="/FS_BN_GL_utils/"
+    atlas_utils_folder=/FS_BN_GL_utils/
     brainstem_structures=false
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,0 +1,13 @@
+process {
+    tag = { "$sid" }
+    publishDir = {"./results/"}
+    scratch = true
+    stageInMode = 'copy'
+    stageOutMode = 'rsync'
+}
+
+params {
+    nb_threads=4
+    atlas_utils_folder="/FS_BN_GL_utils/"
+    brainstem_structures=false
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,5 +1,5 @@
 process {
-    tag = { "$sid" }
+    tag = {"$sid"}
     publishDir = {"./results/"}
     scratch = true
     stageInMode = 'copy'
@@ -7,7 +7,11 @@ process {
 }
 
 params {
-    nb_threads=4
-    atlas_utils_folder=/FS_BN_GL_utils/
-    brainstem_structures=false
+    root_fs_input = false
+    root_fs_output = false
+    help = false
+
+    nb_threads = 4
+    atlas_utils_folder = /FS_BN_GL_utils /
+    brainstem_structures = false
 }


### PR DESCRIPTION
Transfert from the bitbucket, addition of a process to generate connectivity friendly version of atlases (Freesurfer, Brainnetome and Glasser).

The user can either give T1 and compute freesurfer first. But since it may be more optimal to run freesurfer on CBrain, another input is a list of folder output by freesurfer (as is, copy/paste) and then it will only generate the connectivity friendly atlases.

The --brainstem_structures cannot be used if freesurfer was run without it
It must be used with the singularity on braindata/containers/freesurfer_FS_GN_FL_atlas/